### PR TITLE
Add ordering field in Album.all_images def

### DIFF
--- a/opps/articles/models.py
+++ b/opps/articles/models.py
@@ -131,7 +131,8 @@ class Article(Publishable, Slugged):
         imgs = [self.main_image]
         images = self.images.filter(
             published=True, date_available__lte=timezone.now()
-        )
+        ).order_by('articleimage__order', '-date_available')
+
         if self.main_image:
             images = images.exclude(pk=self.main_image.pk)
         imgs += [i for i in images.distinct()]


### PR DESCRIPTION
the definition for all_images in the Article model does not respect the 'order' field. I made a change to put the order_by in this definition starting from the order field ascending, ending in the date_available field descending.
