### PR TITLE
Including djangorestframework as requirement. Closes #278

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ django-celery
 feedparser
 mimeparse
 redis
+djangorestframework


### PR DESCRIPTION
Fresh install requires djangorestframework that isn't on requirements.txt.
