### PR TITLE
Issue #325 Fixed Getting Started guide w/o github set-up

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -14,7 +14,7 @@ Start
 
 .. code-block:: bash
 
-    git clone git@github.com:opps/opps.git
+    git clone https://github.com/opps/opps.git
     cd opps
     python setup.py develop
     opps-admin.py startproject PROJECT_NAME


### PR DESCRIPTION
The published command was not working when the user did not have the git client set-up with the public-key. Changed to clone it from https instead.

Fixed issue #325
