### PR TITLE
fix: query args that use list arguments must be splited

### DIFF
--- a/opps/containers/templatetags/container_tags.py
+++ b/opps/containers/templatetags/container_tags.py
@@ -414,11 +414,20 @@ def get_container_by_channel(slug, number=10, depth=1,
     box = None
     magic_date = kwargs.pop('magic_date', False)
     date = timezone.now()
+
     if magic_date:
         try:
             date = magicdate(magic_date)
         except Exception:
             pass
+
+    # __in split treatment
+    splited = {
+        key: value.split(',')
+        for key, value
+        in kwargs.items()
+        if key.endswith('__in') and type(value) is not list}
+    kwargs.update(splited)
 
     if include_children:
         try:


### PR DESCRIPTION
Our case was when passing _child_class__in_ from template it came as a joined string 'A,B,C,' so the easiest solution was to create a splited dict from those kwarguments and update our kwargs before using on filter.
