### PR TITLE
waffle.io Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://badge.waffle.io/opps/opps.png?label=ready&title=Ready 
+ :target: https://waffle.io/opps/opps
+ :alt: 'Stories in Ready'
 =============================
 Opps - OPen Publishing System
 =============================


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/opps/opps

This was requested by a real person (user mauler) on waffle.io, we're not trying to spam you.
