### PR TITLE
Fixes opps View class for class based views

### DIFF
--- a/opps/views/generic/base.py
+++ b/opps/views/generic/base.py
@@ -18,17 +18,15 @@ class View(object):
     paginate_by = settings.OPPS_PAGINATE_BY
     limit = settings.OPPS_VIEWS_LIMIT
     page_kwarg = 'page'
-    slug = None
-    channel = None
-    long_slug = None
-    article = None
-    child_class = u'container'
 
     def __init__(self, *args, **kwargs):
-        kwargs.update({
-            'channel_long_slug': [],
-            'excluded_ids': set(),
-        })
+        self.slug = None
+        self.channel = None
+        self.long_slug = None
+        self.article = None
+        self.child_class = u'container'
+        self.channel_long_slug = []
+        self.excluded_ids = set()
         super(View, self).__init__(*args, **kwargs)
 
     def get_paginate_by(self, queryset):


### PR DESCRIPTION
The **init** was not accepting args and kwargs. So every CBV on opps was not accepting to override default paramters using **as_view**.

Reference: 
https://docs.djangoproject.com/en/dev/ref/class-based-views/base/#django.views.generic.base.View.as_view
