### PR TITLE
Adds helper to ContainerBox model

### DIFF
--- a/opps/containers/models.py
+++ b/opps/containers/models.py
@@ -366,6 +366,12 @@ class ContainerBox(BaseBox):
         self.local_cache['ordered_box_containers'] = qs
         return qs
 
+    def get_containers_queryset(self):
+        if self.queryset:
+            return self.queryset.get_queryset()
+        else:
+            return self.ordered_containers()
+
     def get_queryset(self, exclude_ids=None, use_local_cache=True):
         cached = self.local_cache.get('get_queryset')
         if use_local_cache and cached:


### PR DESCRIPTION
Without this help to create a simple containerbox you need to use
second template (via include) to list the queryset objects or
the chosen objects. (Check slider-home.html on the core project)
