### PR TITLE
Fixes the use of template_name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 0.2.7
 =====
 
+* opps DetailView and ListView accepts template_name parameter via custom urls.
 * Create a management command exportcontainerbox to easy dump channel and box data
 * Create a management command update_channel_denormalization to update denormalized data
 
@@ -14,7 +15,7 @@ Changelog
 * Uses Grappelli 2.5.3
 * Remove OPPS_CORE_APPS
 * Used opps.core.manager on Container
-* * Extend Polymorphic Manager 
+* * Extend Polymorphic Manager
 * Used channel_id on container unique_together
 * Upgrade Django version to 1.5.9 (Security releases issued https://www.djangoproject.com/weblog/2014/aug/20/security/)
 

--- a/opps/views/generic/detail.py
+++ b/opps/views/generic/detail.py
@@ -31,6 +31,9 @@ class DetailView(View, DjangoDetailView):
         return templates
 
     def get_template_names(self):
+        if self.template_name:
+            return [self.template_name]
+
         domain_folder = self.get_template_folder()
         template_list = self.get_template_list(domain_folder)
 

--- a/opps/views/generic/list.py
+++ b/opps/views/generic/list.py
@@ -68,6 +68,9 @@ class ListView(View, DjangoListView):
         return templates
 
     def get_template_names(self):
+        if self.template_name:
+            return [self.template_name]
+
         domain_folder = self.get_template_folder()
         template_list = self.get_template_list(domain_folder)
 


### PR DESCRIPTION
The django generic views (detail and list) accepts the parameter
template_name to define the template, so opps generic views also
needs.
