### PR TITLE
Fix haystack search returning containers of unpublished channel

### DIFF
--- a/opps/core/managers.py
+++ b/opps/core/managers.py
@@ -14,6 +14,8 @@ class PublishableQuerySet(models.query.QuerySet):
         return {
             '%sdate_available__lte' % prefix: timezone.now(),
             '%spublished' % prefix: True,
+            '%schannel__date_available__lte' % prefix: timezone.now(),
+            '%schannel__published' % prefix: True,
         }
 
 


### PR DESCRIPTION
#416

NOTE: 
The only places that use the 'all_published' method are:
- opps.containers.search_indexes.ContainerIndex.index_queryset
- opps.containers.templatetags.container_tags.get_tags_counter

Tested and my changes don't broke the system.
