### PR TITLE
Load opps.fields on context (view render)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+0.2.11 - dev
+============
+
+* Automatic conversion of opps.fields for the context of the template, #430
+* * Normalization of the name of the variable to use in django template
+
 0.2.10.1
 ========
 * Hot fix opps.core.permissions data migration if not installed opps.contrib.multisite, #402

--- a/docs/documentation/content_architecture.md
+++ b/docs/documentation/content_architecture.md
@@ -220,3 +220,13 @@ update by itself based on some params:
 
 Custom fields
 ====================
+
+To work with custom fields need to create the field in `admin` and use the context in the template:
+
+    {% if context.fields.articlespost_checkbox_show_main_image_yes == 1 %}
+
+or via templatetag:
+
+    {% get_custom_field_value context 'articlespost-checkbox-show-main-image_yes' as new_name_you_var %}
+    {% if new_name_you_var == 1 %}
+

--- a/opps/containers/models.py
+++ b/opps/containers/models.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import json
 import operator
 
 from django.db import models
@@ -189,9 +190,8 @@ class Container(PolymorphicModel, ShowFieldContent, Publishable, Slugged,
         return obj.filter(container=self.id)
 
     def custom_fields(self):
-        import json
         if not self.json:
-            return
+            return {}
         return json.loads(self.json)
 
 

--- a/opps/fields/utils.py
+++ b/opps/fields/utils.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+def field_template_read(obj):
+    """Use replace because the django template can't read variable with "-"
+    """
+    fields = {}
+    for o in obj:
+        fields[o.replace("-", "_")] = obj[o]
+
+    return fields

--- a/opps/views/generic/base.py
+++ b/opps/views/generic/base.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
@@ -10,6 +9,7 @@ from django.contrib.sites.models import get_current_site
 from opps.articles.models import Album
 from opps.containers.models import Container, ContainerBox
 from opps.channels.models import Channel
+from opps.fields.utils import field_template_read
 
 
 class View(object):
@@ -134,6 +134,13 @@ class View(object):
         if self.request.META.get('HTTP_X_PJAX', False) or \
            self.request.is_ajax():
             context['extends_parent'] = 'base_ajax.html'
+
+        try:
+            # opps.field append on context
+            context['context'].fields = field_template_read(
+                context['context'].custom_fields())
+        except AttributeError:
+            pass
 
         return context
 

--- a/tests/fields/test_utils.py
+++ b/tests/fields/test_utils.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from django.test import TestCase
+
+from opps.fields.utils import field_template_read
+
+
+class FieldTemplateReadlTest(TestCase):
+
+    def setUp(self):
+        self.dict = {"articlespost-checkbox-show-main-image_yes": "1"}
+        self.dict_out = {"articlespost_checkbox_show_main_image_yes": "1"}
+
+    def test_self_dict(self):
+        read_on_template = field_template_read(self.dict)
+
+        self.assertNotEqual(self.dict, self.dict_out)
+        self.assertTrue(read_on_template)
+        self.assertEqual(read_on_template, self.dict_out)
+
+    def test_empty_dict(self):
+        """Dict empty is false in Python"""
+        read_on_template = field_template_read({})
+        self.assertFalse(read_on_template)
+        self.assertEqual(read_on_template, {})
+
+
+    def test_down_case(self):
+        read_on_template = field_template_read(self.dict_out)
+        self.assertEqual(read_on_template, self.dict_out)


### PR DESCRIPTION
Today we have a templatetag to do this job, this will be the native method without using templatetag, the idea for the custom field is to be native fields (so nothing better to be loaded automatically in the context!

today via templatetags:

    {% get_custom_field_value context 'articlespost-checkbox-show-main-image_yes' as new_name_you_var %}
    {% if new_name_you_var == 1 %}

proposal:

    {% if context.fields.articlespost_checkbox_show_main_image_yes == 1 %}


Native json (`opps.fields`) conversion and we don't have to call a templatetag to do the loading!

#430 