### PR TITLE
Fix embed compatibility for containers

### DIFF
--- a/opps/containers/templatetags/container_tags.py
+++ b/opps/containers/templatetags/container_tags.py
@@ -6,7 +6,6 @@ from django import template
 from django.conf import settings
 from django.utils import timezone
 from django.utils.safestring import mark_safe
-from django.template.defaultfilters import linebreaksbr
 from django.core.cache import cache
 from django.contrib.sites.models import Site
 
@@ -278,9 +277,6 @@ def get_post_content(post, template_name='containers/post_related.html',
     if not hasattr(post, content_field):
         return None
     content = getattr(post, content_field, '')
-
-    # REMOVE NEW LINES
-    content = linebreaksbr(content)
 
     # Fix embed allowfullscreen
     # TinyMCE BUG


### PR DESCRIPTION
This is a necessary and fast measure to keep inserted embed codes untouched. Also, this filter doesn't look to be useful since the bundled WYSISYG will always wrap content into HTML block elements such as P or DIVs.

This contributes to solve a known issue in some private websites that use Opps as their base CMS.