### PR TITLE
Removed csrf_exempt from views.py

### DIFF
--- a/opps/contrib/fileupload/views.py
+++ b/opps/contrib/fileupload/views.py
@@ -22,7 +22,6 @@ def response_mimetype(request):
     return "text/plain"
 
 
-@csrf_exempt
 @login_required(login_url='/admin/')
 def image_create(request, container_pk=None):
 


### PR DESCRIPTION
In file: views.py, method: image_create, Cross Site Request Forgery protection is exempted on a view using a decorator. A user of this application may be tricked by an attacker to click on a link or visit a malicious website. iCR removed the decorator responsible for CSRF exemption. 

**Sponsorship and Support:**

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed - to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.